### PR TITLE
feat: flip & next-card quiz loop

### DIFF
--- a/public/decks/sample.json
+++ b/public/decks/sample.json
@@ -1,5 +1,27 @@
-{
-  "id": "bun_high",
-  "front": "BUN > 25 mg/dL",
-  "back": ["高蛋白食/脱水/腎機能低下 などが考えられる"]
-}
+[
+  {
+    "id": "bun_high",
+    "front": "BUN > 25 mg/dL",
+    "back": ["高蛋白食/脱水/腎機能低下 などが考えられる"]
+  },
+  {
+    "id": "creatinine_high",
+    "front": "Creatinine > 1.2 mg/dL",
+    "back": ["腎機能低下の可能性がある"]
+  },
+  {
+    "id": "ast_alt_high",
+    "front": "AST/ALT > 40 U/L",
+    "back": ["肝機能障害の可能性がある"]
+  },
+  {
+    "id": "wbc_high",
+    "front": "WBC > 10,000/μL",
+    "back": ["感染症/炎症/白血病 などが考えられる"]
+  },
+  {
+    "id": "hb_low",
+    "front": "Hb < 13 g/dL (男性) / < 12 g/dL (女性)",
+    "back": ["貧血の可能性がある"]
+  }
+]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,43 +1,98 @@
 import { useState, useEffect } from 'react'
 import './App.css'
 import type { Card } from './types'
+import CardComponent from './components/Card'
 
 function App() {
-  const [card, setCard] = useState<Card | null>(null);
+  const [cards, setCards] = useState<Card[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    // Load the sample card from the JSON file
+  // Load and shuffle cards
+  const loadAndShuffleCards = () => {
+    setIsLoading(true);
     fetch('./decks/sample.json')
       .then(response => response.json())
-      .then(data => setCard(data))
-      .catch(error => console.error('Error loading card:', error));
-  }, []);
-
-  const handleCardClick = () => {
-    setIsFlipped(!isFlipped);
+      .then(data => {
+        // Convert single card to array if needed
+        const cardArray = Array.isArray(data) ? data : [data];
+        // Shuffle the cards
+        const shuffledCards = [...cardArray].sort(() => Math.random() - 0.5);
+        setCards(shuffledCards);
+        setCurrentIndex(0);
+        setIsFlipped(false);
+        setIsLoading(false);
+      })
+      .catch(error => {
+        console.error('Error loading cards:', error);
+        setIsLoading(false);
+      });
   };
 
-  if (!card) {
+  useEffect(() => {
+    loadAndShuffleCards();
+  }, []);
+
+  const handleCardFlip = () => {
+    setIsFlipped(true);
+  };
+
+  const handleNextCard = () => {
+    setCurrentIndex(prevIndex => prevIndex + 1);
+    setIsFlipped(false);
+  };
+
+  const handleRestart = () => {
+    loadAndShuffleCards();
+  };
+
+  if (isLoading) {
     return <div className="flex justify-center items-center h-screen">Loading...</div>;
   }
 
-  return (
-    <div className="flex justify-center items-center h-screen bg-gray-100">
-      <div 
-        onClick={handleCardClick}
-        className="w-96 h-64 bg-white rounded-lg shadow-lg border-2 border-gray-300 cursor-pointer flex items-center justify-center p-6 transition-all duration-300 hover:shadow-xl"
-      >
-        {!isFlipped ? (
-          <div className="text-center text-2xl font-bold">{card.front}</div>
-        ) : (
-          <div className="text-center">
-            {card.back.map((line, index) => (
-              <p key={index} className="mb-2">{line}</p>
-            ))}
-          </div>
-        )}
+  if (cards.length === 0) {
+    return <div className="flex justify-center items-center h-screen">No cards found.</div>;
+  }
+
+  const isLastCard = currentIndex >= cards.length - 1;
+  const currentCard = cards[currentIndex];
+
+  // If we've gone through all cards
+  if (currentIndex >= cards.length) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen bg-gray-100 p-4">
+        <div className="text-2xl font-bold mb-6">デッキ完了！🎉</div>
+        <button 
+          onClick={handleRestart}
+          className="px-6 py-2 bg-blue-500 text-white rounded-lg shadow hover:bg-blue-600 transition-colors"
+        >
+          Restart
+        </button>
       </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen bg-gray-100 p-4">
+      <div className="mb-8 text-lg">
+        {currentIndex + 1} / {cards.length}
+      </div>
+      
+      <CardComponent 
+        card={currentCard} 
+        onFlip={handleCardFlip} 
+        isFlipped={isFlipped} 
+      />
+      
+      {isFlipped && (
+        <button 
+          onClick={isLastCard ? handleRestart : handleNextCard}
+          className="mt-8 px-6 py-2 bg-blue-500 text-white rounded-lg shadow hover:bg-blue-600 transition-colors"
+        >
+          {isLastCard ? 'Restart' : 'Next ▶︎'}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,37 @@
+// Card component for displaying flashcards
+import type { Card as CardType } from '../types';
+
+interface CardProps {
+  card: CardType;
+  onFlip: () => void;
+  isFlipped: boolean;
+}
+
+export default function Card({ card, onFlip, isFlipped }: CardProps) {
+  const handleClick = () => {
+    if (!isFlipped) {
+      onFlip();
+    }
+  };
+
+  return (
+    <div 
+      onClick={handleClick}
+      className={`w-96 h-64 bg-white rounded-lg shadow-lg border-2 border-gray-300 
+                 flex items-center justify-center p-6 transition-all duration-300 hover:shadow-xl
+                 ${isFlipped ? 'cursor-default' : 'cursor-pointer'}`}
+    >
+      <div className="text-center text-black">
+        {!isFlipped ? (
+          <div className="text-2xl font-bold">{card.front}</div>
+        ) : (
+          <div>
+            {card.back.map((line, index) => (
+              <p key={index} className="mb-2">{line}</p>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 🌊 Windsurf — Milestone 1 / Basic Quiz Loop

## 実装内容
- カード反転フローと次カード遷移機能の実装
- 進捗表示の追加
- デッキ完了後の再開機能
- 複数カードサンプルの追加

## Definition of Done
- [x] `npm run dev` でブラウザに **表 → 裏 → Next** フローが動作
- [x] 進捗表示が現在枚数をリアルタイム更新
- [x] `Restart` でデッキがランダム順に再開
- [x] スタイルは Tailwind でシンプル中央配置
- [x] ESLint / TypeScript エラー 0
- [x] 差分 ≤ 250 LOC